### PR TITLE
Paavos edits

### DIFF
--- a/Exercises-with-open-data/Pseudorapidity-resolution.ipynb
+++ b/Exercises-with-open-data/Pseudorapidity-resolution.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "<img src=\"../Images/Pseudorapidity_plot.png\" alt=\"Image of pseudorapidity values\" style=\"height: 200px\">\n",
     "\n",
-    "(Image: Wikimedia user Mets501, https://en.wikipedia.org/wiki/Pseudorapidity#/media/File:Pseudorapidity_plot.svg)\n",
+    "(Image: Wikimedia user Mets501, Own work, CC BY-SA 3.0, https://commons.wikimedia.org/w/index.php?curid=20392149)\n",
     "<br>\n",
     "<br>\n",
     "<br>"
@@ -138,6 +138,8 @@
    "metadata": {},
    "source": [
     "<img src=\"../Images/Pseudorapidity_plot.png\" alt=\"Image of pseudorapidity values\" style=\"height: 200px\">\n",
+    "\n",
+    "(Image: Wikimedia user Mets501, Own work, CC BY-SA 3.0, https://commons.wikimedia.org/w/index.php?curid=20392149)\n",
     "\n",
     "First we will select from all the events into two groups the events where the pseudorapidity of the two muons have been relatively large (e.g. $\\eta$ > 1.52) and relatively small (e.g. $\\eta$ < 0.45). The selection is made with the code below. We want about the same amount of events to both groups so that the comparison could be done.\n",
     "\n",

--- a/Introduction-to-jupyter/Jupyter-getting-started.ipynb
+++ b/Introduction-to-jupyter/Jupyter-getting-started.ipynb
@@ -492,7 +492,7 @@
    "source": [
     "Information for example about the position and the size of the image can be added to the HTML tag. For example an image can be aligned to left with the following tag:\n",
     "\n",
-    "<font color=\"blue\"> ``<img src=\"../Images/test-image.png\" align=\"left\">`` </font>.\n",
+    "``<img src=\"../Images/test-image.png\" align=\"left\">``.\n",
     "\n",
     "Note that setting alignment can make the text appear on the side of the image. You can \"push\" the text lower by adding linebreaks ``<br>``.\n",
     "\n",
@@ -526,7 +526,7 @@
    "source": [
     "In the tag the _type_ determines the file format of the video which is in this example .mp4. Command _controls_ creates the buttons that are needed to play the video. More information about the HTML video tags can be found from https://www.w3schools.com/tags/tag_video.asp.\n",
     "\n",
-    "The video added in the notebook can for example look like this:\n",
+    "The video added in the notebook can for example look like this (note that the video might not be viewable straight in GitHub):\n",
     "\n",
     "<video src=\"../Videos/test-video.mp4\" type=\"video/mp4\" controls>"
    ]


### PR DESCRIPTION
- Small edits to image captions in pseudaorapidity images in "Pseudorapidity-resolution.ipynb".
- Note to the video in "Jupyter-getting-started.ipynb".
- One image tag that was meant to be shown as an example wasn't visible. I deleted font colour tag from that so it became visible.